### PR TITLE
Plan API Swagger Document

### DIFF
--- a/backend/src/dto/plan.detail.response.dto.ts
+++ b/backend/src/dto/plan.detail.response.dto.ts
@@ -1,0 +1,82 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+} from 'class-validator';
+
+export enum PlanStatus {
+  PLANNING = '계획중',
+  ING = '여행중',
+  END = '여행완료',
+}
+
+export class PlanDetailResponseDto {
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
+  // 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카톡 프로필 이미지 (string array)
+
+  @ApiProperty({
+    example: '1',
+    description: '여행계획 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public planId: number;
+
+  @ApiProperty({
+    example: '1',
+    description: '소유자 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public userId: number;
+
+  @ApiProperty({
+    example: '4',
+    description: '동행 인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public groupNum: number;
+
+  @ApiProperty({
+    example: 'east, west, south',
+    description: '지역 리스트 (string ,으로 구분)',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public regionList: string;
+
+  @ApiProperty({
+    example: '2023-12-21',
+    description: '여행 시작일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public startDate: Date;
+
+  @ApiProperty({
+    example: '2023-12-24',
+    description: '여행 종료일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public endDate: Date;
+
+  @ApiProperty({
+    example: '계획중',
+    description: '상태 (계획중, 여행중, 여행완료 중 1개)',
+    required: true,
+  })
+  @IsEnum(PlanStatus)
+  @IsNotEmpty()
+  public status: string;
+}

--- a/backend/src/dto/plan.detail.response.dto.ts
+++ b/backend/src/dto/plan.detail.response.dto.ts
@@ -14,8 +14,8 @@ export enum PlanStatus {
 }
 
 export class PlanDetailResponseDto {
-  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
-  // 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카톡 프로필 이미지 (string array)
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 설문 주소 (string), 동행 인원 (Number), 지역 (east, west, south, north)
+  // 취향설문참여인원 (int), 여행지설문참여인원 (int), 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)
 
   @ApiProperty({
     example: '1',
@@ -36,6 +36,15 @@ export class PlanDetailResponseDto {
   public userId: number;
 
   @ApiProperty({
+    example: 'https://tripwiz.com/abcdedf',
+    description: '설문 주소',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public link: string;
+
+  @ApiProperty({
     example: '4',
     description: '동행 인원',
     required: true,
@@ -52,6 +61,24 @@ export class PlanDetailResponseDto {
   @IsString()
   @IsNotEmpty()
   public regionList: string;
+
+  @ApiProperty({
+    example: 4,
+    description: '취향설문참여인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public categoryParticipants: number;
+
+  @ApiProperty({
+    example: 4,
+    description: '여행지설문참여인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public spotParticipants: number;
 
   @ApiProperty({
     example: '2023-12-21',

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -2,11 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class PlanRequestDto {
-  // 유저 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
+  // 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
 
   @ApiProperty({
     example: '1',
-    description: '유저 아이디',
+    description: '소유자 아이디',
     required: true,
   })
   @IsNumber()

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
-export class PlanRequenstDto {
+export class PlanRequestDto {
   // 유저 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
 
   @ApiProperty({

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -1,17 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { UserResponseDto } from './user.response.dto';
 
 export class PlanRequestDto {
-  // 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
+  // 소유자 정보 (UserResponseDto), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
 
   @ApiProperty({
-    example: '1',
-    description: '소유자 아이디',
+    example:
+      '{아이디: 1, 이메일: "abc@gmail.com", 닉네임: "홍길동", 프로필 이미지: "https://s3.amazon.com/image/abc"}',
+    description: '소유자 정보',
     required: true,
   })
-  @IsNumber()
+  // TODO: UserResponseDto type인지 확인하는 decorater
   @IsNotEmpty()
-  public userId: number;
+  public user: UserResponseDto;
 
   @ApiProperty({
     example: '4',

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class PlanRequenstDto {
+  // 유저 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
+
+  @ApiProperty({
+    example: '1',
+    description: '유저 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public userId: number;
+
+  @ApiProperty({
+    example: '4',
+    description: '동행 인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public groupNum: number;
+
+  @ApiProperty({
+    example: 'east, west, south',
+    description: '지역 리스트 (string ,으로 구분)',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public regionList: string;
+
+  @ApiProperty({
+    example: '2023-12-21',
+    description: '여행 시작일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public startDate: Date;
+
+  @ApiProperty({
+    example: '2023-12-24',
+    description: '여행 종료일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public endDate: Date;
+}

--- a/backend/src/dto/plan.simple.response.dto.ts
+++ b/backend/src/dto/plan.simple.response.dto.ts
@@ -1,0 +1,94 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Validate,
+  ValidateNested,
+} from 'class-validator';
+import { PlanStatus } from './plan.detail.response.dto';
+import { Type } from 'class-transformer';
+
+export class PlanSimpleResponseDto {
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
+  // 여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)
+  // 카카오톡 프로필 (string [])
+
+  @ApiProperty({
+    example: '1',
+    description: '여행계획 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public planId: number;
+
+  @ApiProperty({
+    example: '1',
+    description: '소유자 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public userId: number;
+
+  @ApiProperty({
+    example: '4',
+    description: '동행 인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public groupNum: number;
+
+  @ApiProperty({
+    example: 'east, west, south',
+    description: '지역 리스트 (string ,으로 구분)',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public regionList: string;
+
+  @ApiProperty({
+    example: '2023-12-21',
+    description: '여행 시작일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public startDate: Date;
+
+  @ApiProperty({
+    example: '2023-12-24',
+    description: '여행 종료일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public endDate: Date;
+
+  @ApiProperty({
+    example: '계획중',
+    description: '상태 (계획중, 여행중, 여행완료 중 1개)',
+    required: true,
+  })
+  @IsEnum(PlanStatus)
+  @IsNotEmpty()
+  public status: string;
+
+  @ApiProperty({
+    example: '["https://image1.jpg", "https://image2.jpg"]',
+    description: '카카오톡 프로필',
+    required: true,
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => String)
+  @IsString()
+  @IsNotEmpty()
+  public profileImg: string[];
+}

--- a/backend/src/dto/plan.simple.response.dto.ts
+++ b/backend/src/dto/plan.simple.response.dto.ts
@@ -13,9 +13,8 @@ import { PlanStatus } from './plan.detail.response.dto';
 import { Type } from 'class-transformer';
 
 export class PlanSimpleResponseDto {
-  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
-  // 여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)
-  // 카카오톡 프로필 (string [])
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number)
+  // 여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카카오톡 프로필 (string [])
 
   @ApiProperty({
     example: '1',
@@ -43,15 +42,6 @@ export class PlanSimpleResponseDto {
   @IsNumber()
   @IsNotEmpty()
   public groupNum: number;
-
-  @ApiProperty({
-    example: 'east, west, south',
-    description: '지역 리스트 (string ,으로 구분)',
-    required: true,
-  })
-  @IsString()
-  @IsNotEmpty()
-  public regionList: string;
 
   @ApiProperty({
     example: '2023-12-21',

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
   UseGuards,
   Param,
+  Query,
 } from '@nestjs/common';
 import { PlansService } from './plans.service';
 import {
@@ -42,7 +43,7 @@ export class PlansController {
     //TODO : 여행 계획 생성하기
     const plan = await this.plansService.createPlan(
       // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
-      body.userId,
+      body.user.id,
       body.groupNum,
       body.regionList,
       body.startDate,
@@ -80,11 +81,11 @@ export class PlansController {
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 id로 조회하기' })
-  @Get(':id')
-  async getPlanWithId(@Param('id') id: number) {
-    //TODO : 여행 계획 link주소로 조회하기
+  @Get()
+  async getPlanWithId(@Query('planId') planId: number) {
+    //TODO : 여행 계획 id로 조회하기
     //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
-    const plan = await this.plansService.getPlanWithId(id);
+    const plan = await this.plansService.getPlanWithId(planId);
     if (plan) {
       return plan;
     } else {
@@ -101,8 +102,8 @@ export class PlansController {
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 링크로 조회하기' })
-  @Get(':hashId')
-  async getPlanWithHashId(@Param('hashId') hashId: string) {
+  @Get()
+  async getPlanWithHashId(@Query('hashId') hashId: string) {
     //TODO : 여행 계획 link주소로 조회하기
     //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
     const plan = await this.plansService.getPlanWithHashId(hashId);

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -17,7 +17,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { LoggedInGuard } from 'src/auth/logged-in-guard';
-import { PlanRequenstDto } from 'src/dto/plan.request.dto';
+import { PlanRequestDto } from 'src/dto/plan.request.dto';
 import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
 import { ErrorResponseDto } from 'src/dto/error.response.dto';
 import { PlanSimpleResponseDto } from 'src/dto/plan.simple.response.dto';
@@ -38,7 +38,7 @@ export class PlansController {
   @ApiOperation({ summary: '여행 계획 생성하기' })
   @Post()
   @UseGuards(LoggedInGuard)
-  async createPlan(@Body() body: PlanRequenstDto) {
+  async createPlan(@Body() body: PlanRequestDto) {
     //TODO : 여행 계획 생성하기
     const plan = await this.plansService.createPlan(
       // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -1,46 +1,138 @@
-import { Controller, Delete, Get, Post, Put, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  Post,
+  Put,
+  UseGuards,
+  Param,
+} from '@nestjs/common';
 import { PlansService } from './plans.service';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { LoggedInGuard } from 'src/auth/logged-in-guard';
+import { PlanRequenstDto } from 'src/dto/plan.request.dto';
+import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
+import { ErrorResponseDto } from 'src/dto/error.response.dto';
+import { PlanSimpleResponseDto } from 'src/dto/plan.simple.response.dto';
 
 @ApiTags('PLAN')
 @Controller('api/plans')
 export class PlansController {
   constructor(private plansService: PlansService) {}
 
+  @ApiOkResponse({
+    description: '여행 계획 생성 성공',
+    type: PlanDetailResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
   @ApiOperation({ summary: '여행 계획 생성하기' })
   @Post()
   @UseGuards(LoggedInGuard)
-  createPlan() {
+  async createPlan(@Body() body: PlanRequenstDto) {
     //TODO : 여행 계획 생성하기
+    const plan = await this.plansService.createPlan(
+      // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
+      body.userId,
+      body.groupNum,
+      body.regionList,
+      body.startDate,
+      body.endDate,
+    );
+    if (plan) {
+      return plan;
+    } else {
+      throw new ForbiddenException();
+    }
   }
 
   @ApiOperation({ summary: '여행 계획 수정하기' })
   @Put()
   @UseGuards(LoggedInGuard)
-  updatePlan() {
+  async updatePlan() {
     //TODO : 여행 계획 수정하기
+    // 일단 skip
   }
 
   @ApiOperation({ summary: '여행 계획 삭제하기' })
   @Delete()
   @UseGuards(LoggedInGuard)
-  deletePlan() {
+  async deletePlan() {
     //TODO : 여행 계획 삭제하기
+    // 일단 skip
   }
 
+  @ApiOkResponse({
+    description: '여행 계획 조회 성공',
+    type: PlanDetailResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
   @ApiOperation({ summary: '여행 계획 id로 조회하기' })
-  @Get()
-  getPlan() {
+  @Get(':id')
+  async getPlanWithId(@Param('id') id: number) {
     //TODO : 여행 계획 link주소로 조회하기
     //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
+    const plan = await this.plansService.getPlanWithId(id);
+    if (plan) {
+      return plan;
+    } else {
+      throw new ForbiddenException();
+    }
   }
 
-  @ApiOperation({ summary: '내가 속한 모든 여행 조회하기' })
-  @Get('all')
+  @ApiOkResponse({
+    description: '여행 계획 조회 성공',
+    type: PlanDetailResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
+  @ApiOperation({ summary: '여행 계획 링크로 조회하기' })
+  @Get(':hashId')
+  async getPlanWithHashId(@Param('hashId') hashId: string) {
+    //TODO : 여행 계획 link주소로 조회하기
+    //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
+    const plan = await this.plansService.getPlanWithHashId(hashId);
+    if (plan) {
+      return plan;
+    } else {
+      throw new ForbiddenException();
+    }
+  }
+
+  @ApiOkResponse({
+    description: '내가 속한 모든 여행 조회 성공',
+    type: PlanSimpleResponseDto,
+    isArray: true,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
+  @ApiOperation({ summary: '사용자 id로 사용자가 속한 모든 여행 조회하기' })
+  @Get('all/:id')
   @UseGuards(LoggedInGuard)
-  getAllPlan() {
+  getAllPlan(@Param('id') id: number) {
     //TODO : 내가 속한 모든 여행 조회하기
-    //세부 사항이 아니라, 간단하게 현황과 날짜, 참여하고 있는 사람들의 프사같은 정보
+    // 세부 사항이 아니라, 간단하게 현황과 날짜, 참여하고 있는 사람들의 프사같은 정보
+    const planList = this.plansService.getAllPlan(id);
+    if (planList) {
+      return planList;
+    } else {
+      throw new ForbiddenException();
+    }
   }
 }

--- a/backend/src/plans/plans.service.ts
+++ b/backend/src/plans/plans.service.ts
@@ -26,12 +26,12 @@ export class PlansService {
   }
 
   async getPlanWithId(id: number) {
-    //TODO : 여행 계획 조회하기
+    //TODO : 여행 계획 id로 조회하기
     return true;
   }
 
   async getPlanWithHashId(hash: string) {
-    //TODO : 여행 계획 조회하기
+    //TODO : 여행 계획 hash id로 조회하기
     return true;
   }
 

--- a/backend/src/plans/plans.service.ts
+++ b/backend/src/plans/plans.service.ts
@@ -1,4 +1,42 @@
 import { Injectable } from '@nestjs/common';
+import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
 
 @Injectable()
-export class PlansService {}
+export class PlansService {
+  constructor() {}
+
+  async createPlan(
+    userId: number,
+    groupNum: number,
+    regionList: string,
+    startDate: Date,
+    endDate: Date,
+  ) {
+    //TODO : 여행 계획 생성하기
+    // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
+    return true;
+  }
+
+  async updatePlan() {
+    //TODO : 여행 계획 수정하기
+  }
+
+  async deletePlan() {
+    //TODO : 여행 계획 삭제하기
+  }
+
+  async getPlanWithId(id: number) {
+    //TODO : 여행 계획 조회하기
+    return true;
+  }
+
+  async getPlanWithHashId(hash: string) {
+    //TODO : 여행 계획 조회하기
+    return true;
+  }
+
+  async getAllPlan(id: number) {
+    //TODO : 여행 계획 전체 조회하기
+    return true;
+  }
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -38,7 +38,7 @@ export class UsersController {
   })
   @ApiOperation({ summary: '내 정보 가져오기' })
   @Get()
-  getUsers(@User() user) {
+  getUsers(@User() user: UserResponseDto) {
     if (!user) throw new NotFoundException();
     return user;
   }


### PR DESCRIPTION
Swagger Document 정리
1. POST /api/plans : PlanRequestDto → PlanDetailResponseDto
2. GET /api/plans/?planId=123 : 123 → PlanDetailResponseDtp (plan id query로 get)
3. GET /api/plans/?hashId=ABC : ABC → PlanDetailResponseDto (링크 hash id query로 get)
4. GET /api/plans/all : ( ) → PlanSimpleResponseDto
5. PUT /api/plans (일단 skip 나중에 구현 예정)
6. DELETE /api/plans (일단 skip 나중에 구현 예정)

- PlanRequestDto
소유자 정보 (UserResponseDto), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)

- PlanSimpleResponseDto
여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number)
여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카카오톡 프로필 (string [])

- PlanDetailResponseDto
여행계획 아이디 (int), 소유자 아이디 (int), 설문 주소 (string), 동행 인원 (Number), 지역 (east, west, south, north)
취향설문참여인원 (int), 여행지설문참여인원 (int), 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)