### PR TITLE
Plan

### DIFF
--- a/backend/src/dto/plan.detail.response.dto.ts
+++ b/backend/src/dto/plan.detail.response.dto.ts
@@ -1,0 +1,82 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+} from 'class-validator';
+
+export enum PlanStatus {
+  PLANNING = '계획중',
+  ING = '여행중',
+  END = '여행완료',
+}
+
+export class PlanDetailResponseDto {
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
+  // 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카톡 프로필 이미지 (string array)
+
+  @ApiProperty({
+    example: '1',
+    description: '여행계획 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public planId: number;
+
+  @ApiProperty({
+    example: '1',
+    description: '소유자 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public userId: number;
+
+  @ApiProperty({
+    example: '4',
+    description: '동행 인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public groupNum: number;
+
+  @ApiProperty({
+    example: 'east, west, south',
+    description: '지역 리스트 (string ,으로 구분)',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public regionList: string;
+
+  @ApiProperty({
+    example: '2023-12-21',
+    description: '여행 시작일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public startDate: Date;
+
+  @ApiProperty({
+    example: '2023-12-24',
+    description: '여행 종료일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public endDate: Date;
+
+  @ApiProperty({
+    example: '계획중',
+    description: '상태 (계획중, 여행중, 여행완료 중 1개)',
+    required: true,
+  })
+  @IsEnum(PlanStatus)
+  @IsNotEmpty()
+  public status: string;
+}

--- a/backend/src/dto/plan.detail.response.dto.ts
+++ b/backend/src/dto/plan.detail.response.dto.ts
@@ -8,7 +8,7 @@ import {
 } from 'class-validator';
 
 export enum PlanStatus {
-  PLANNING = '계획중',
+  READY = '계획중',
   ING = '여행중',
   END = '여행완료',
 }

--- a/backend/src/dto/plan.detail.response.dto.ts
+++ b/backend/src/dto/plan.detail.response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   IsDate,
   IsEnum,
@@ -6,12 +7,7 @@ import {
   IsNumber,
   IsString,
 } from 'class-validator';
-
-export enum PlanStatus {
-  READY = '계획중',
-  ING = '여행중',
-  END = '여행완료',
-}
+import { PlanStatus } from 'src/entities/common/PlanStatus';
 
 export class PlanDetailResponseDto {
   // 여행계획 아이디 (int), 소유자 아이디 (int), 설문 주소 (string), 동행 인원 (Number), 지역 (east, west, south, north)
@@ -54,8 +50,8 @@ export class PlanDetailResponseDto {
   public groupNum: number;
 
   @ApiProperty({
-    example: 'east, west, south',
-    description: '지역 리스트 (string ,으로 구분)',
+    example: '[east, west, south]',
+    description: '지역 리스트 (string ,으로 구분하고 []로 감싸기)',
     required: true,
   })
   @IsString()
@@ -87,6 +83,7 @@ export class PlanDetailResponseDto {
   })
   @IsDate()
   @IsNotEmpty()
+  @Transform(({ value }) => new Date(value))
   public startDate: Date;
 
   @ApiProperty({
@@ -96,6 +93,7 @@ export class PlanDetailResponseDto {
   })
   @IsDate()
   @IsNotEmpty()
+  @Transform(({ value }) => new Date(value))
   public endDate: Date;
 
   @ApiProperty({

--- a/backend/src/dto/plan.detail.response.dto.ts
+++ b/backend/src/dto/plan.detail.response.dto.ts
@@ -14,8 +14,8 @@ export enum PlanStatus {
 }
 
 export class PlanDetailResponseDto {
-  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
-  // 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카톡 프로필 이미지 (string array)
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 설문 주소 (string), 동행 인원 (Number), 지역 (east, west, south, north)
+  // 취향설문참여인원 (int), 여행지설문참여인원 (int), 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)
 
   @ApiProperty({
     example: '1',
@@ -36,6 +36,15 @@ export class PlanDetailResponseDto {
   public userId: number;
 
   @ApiProperty({
+    example: 'https://tripwiz.com/abcdedf',
+    description: '설문 주소',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public link: string;
+
+  @ApiProperty({
     example: '4',
     description: '동행 인원',
     required: true,
@@ -52,6 +61,24 @@ export class PlanDetailResponseDto {
   @IsString()
   @IsNotEmpty()
   public regionList: string;
+
+  @ApiProperty({
+    example: 4,
+    description: '취향설문참여인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public categoryParticipants: number;
+
+  @ApiProperty({
+    example: 4,
+    description: '여행지설문참여인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public spotParticipants: number;
 
   @ApiProperty({
     example: '2023-12-21',

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -2,11 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class PlanRequestDto {
-  // 유저 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
+  // 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
 
   @ApiProperty({
     example: '1',
-    description: '유저 아이디',
+    description: '소유자 아이디',
     required: true,
   })
   @IsNumber()

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
-export class PlanRequenstDto {
+export class PlanRequestDto {
   // 유저 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
 
   @ApiProperty({

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -1,17 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { UserResponseDto } from './user.response.dto';
 
 export class PlanRequestDto {
-  // 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
+  // 소유자 정보 (UserResponseDto), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
 
   @ApiProperty({
-    example: '1',
-    description: '소유자 아이디',
+    example:
+      '{아이디: 1, 이메일: "abc@gmail.com", 닉네임: "홍길동", 프로필 이미지: "https://s3.amazon.com/image/abc"}',
+    description: '소유자 정보',
     required: true,
   })
-  @IsNumber()
+  // TODO: UserResponseDto type인지 확인하는 decorater
   @IsNotEmpty()
-  public userId: number;
+  public user: UserResponseDto;
 
   @ApiProperty({
     example: '4',

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -4,17 +4,6 @@ import { UserResponseDto } from './user.response.dto';
 
 export class PlanRequestDto {
   // 소유자 정보 (UserResponseDto), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
-
-  @ApiProperty({
-    example:
-      '{아이디: 1, 이메일: "abc@gmail.com", 닉네임: "홍길동", 프로필 이미지: "https://s3.amazon.com/image/abc"}',
-    description: '소유자 정보',
-    required: true,
-  })
-  // TODO: UserResponseDto type인지 확인하는 decorater
-  @IsNotEmpty()
-  public user: UserResponseDto;
-
   @ApiProperty({
     example: '4',
     description: '동행 인원',

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
-import { UserResponseDto } from './user.response.dto';
 
 export class PlanRequestDto {
   // 소유자 정보 (UserResponseDto), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
@@ -14,8 +14,8 @@ export class PlanRequestDto {
   public groupNum: number;
 
   @ApiProperty({
-    example: 'east, west, south',
-    description: '지역 리스트 (string ,으로 구분)',
+    example: '[east, west, south]',
+    description: '지역 리스트 (string ,으로 구분하고 []로 감싸기])',
     required: true,
   })
   @IsString()
@@ -29,6 +29,7 @@ export class PlanRequestDto {
   })
   @IsDate()
   @IsNotEmpty()
+  @Transform(({ value }) => new Date(value))
   public startDate: Date;
 
   @ApiProperty({
@@ -38,5 +39,6 @@ export class PlanRequestDto {
   })
   @IsDate()
   @IsNotEmpty()
+  @Transform(({ value }) => new Date(value))
   public endDate: Date;
 }

--- a/backend/src/dto/plan.request.dto.ts
+++ b/backend/src/dto/plan.request.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDate, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class PlanRequenstDto {
+  // 유저 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)
+
+  @ApiProperty({
+    example: '1',
+    description: '유저 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public userId: number;
+
+  @ApiProperty({
+    example: '4',
+    description: '동행 인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public groupNum: number;
+
+  @ApiProperty({
+    example: 'east, west, south',
+    description: '지역 리스트 (string ,으로 구분)',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public regionList: string;
+
+  @ApiProperty({
+    example: '2023-12-21',
+    description: '여행 시작일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public startDate: Date;
+
+  @ApiProperty({
+    example: '2023-12-24',
+    description: '여행 종료일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public endDate: Date;
+}

--- a/backend/src/dto/plan.simple.response.dto.ts
+++ b/backend/src/dto/plan.simple.response.dto.ts
@@ -1,0 +1,94 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  Validate,
+  ValidateNested,
+} from 'class-validator';
+import { PlanStatus } from './plan.detail.response.dto';
+import { Type } from 'class-transformer';
+
+export class PlanSimpleResponseDto {
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
+  // 여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)
+  // 카카오톡 프로필 (string [])
+
+  @ApiProperty({
+    example: '1',
+    description: '여행계획 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public planId: number;
+
+  @ApiProperty({
+    example: '1',
+    description: '소유자 아이디',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public userId: number;
+
+  @ApiProperty({
+    example: '4',
+    description: '동행 인원',
+    required: true,
+  })
+  @IsNumber()
+  @IsNotEmpty()
+  public groupNum: number;
+
+  @ApiProperty({
+    example: 'east, west, south',
+    description: '지역 리스트 (string ,으로 구분)',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  public regionList: string;
+
+  @ApiProperty({
+    example: '2023-12-21',
+    description: '여행 시작일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public startDate: Date;
+
+  @ApiProperty({
+    example: '2023-12-24',
+    description: '여행 종료일',
+    required: true,
+  })
+  @IsDate()
+  @IsNotEmpty()
+  public endDate: Date;
+
+  @ApiProperty({
+    example: '계획중',
+    description: '상태 (계획중, 여행중, 여행완료 중 1개)',
+    required: true,
+  })
+  @IsEnum(PlanStatus)
+  @IsNotEmpty()
+  public status: string;
+
+  @ApiProperty({
+    example: '["https://image1.jpg", "https://image2.jpg"]',
+    description: '카카오톡 프로필',
+    required: true,
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => String)
+  @IsString()
+  @IsNotEmpty()
+  public profileImg: string[];
+}

--- a/backend/src/dto/plan.simple.response.dto.ts
+++ b/backend/src/dto/plan.simple.response.dto.ts
@@ -13,9 +13,8 @@ import { PlanStatus } from './plan.detail.response.dto';
 import { Type } from 'class-transformer';
 
 export class PlanSimpleResponseDto {
-  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number), 지역 (east, west, south, north)
-  // 여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)
-  // 카카오톡 프로필 (string [])
+  // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number)
+  // 여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카카오톡 프로필 (string [])
 
   @ApiProperty({
     example: '1',
@@ -43,15 +42,6 @@ export class PlanSimpleResponseDto {
   @IsNumber()
   @IsNotEmpty()
   public groupNum: number;
-
-  @ApiProperty({
-    example: 'east, west, south',
-    description: '지역 리스트 (string ,으로 구분)',
-    required: true,
-  })
-  @IsString()
-  @IsNotEmpty()
-  public regionList: string;
 
   @ApiProperty({
     example: '2023-12-21',

--- a/backend/src/dto/plan.simple.response.dto.ts
+++ b/backend/src/dto/plan.simple.response.dto.ts
@@ -6,7 +6,6 @@ import {
   IsNotEmpty,
   IsNumber,
   IsString,
-  Validate,
   ValidateNested,
 } from 'class-validator';
 import { PlanStatus } from './plan.detail.response.dto';

--- a/backend/src/dto/plan.simple.response.dto.ts
+++ b/backend/src/dto/plan.simple.response.dto.ts
@@ -8,8 +8,8 @@ import {
   IsString,
   ValidateNested,
 } from 'class-validator';
-import { PlanStatus } from './plan.detail.response.dto';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
+import { PlanStatus } from 'src/entities/common/PlanStatus';
 
 export class PlanSimpleResponseDto {
   // 여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number)
@@ -49,6 +49,7 @@ export class PlanSimpleResponseDto {
   })
   @IsDate()
   @IsNotEmpty()
+  @Transform(({ value }) => new Date(value))
   public startDate: Date;
 
   @ApiProperty({
@@ -58,6 +59,7 @@ export class PlanSimpleResponseDto {
   })
   @IsDate()
   @IsNotEmpty()
+  @Transform(({ value }) => new Date(value))
   public endDate: Date;
 
   @ApiProperty({

--- a/backend/src/entities/Plans.ts
+++ b/backend/src/entities/Plans.ts
@@ -16,17 +16,24 @@ import { CategoryResponses } from './CategoryResponses';
 import { SpotResponses } from './SpotResponses';
 import { Spots } from './Spots';
 import { Recommends } from './Recommends';
+import { PlanStatus } from 'src/dto/plan.detail.response.dto';
 
 @Entity({ schema: 'frienvel', name: 'plans' })
 export class Plans {
   @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
   id: number;
 
+  @Column('int', { name: 'UserId', nullable: true })
+  userId: number;
+
   @Column('varchar', { name: 'link', unique: true, length: 50 })
   link: string;
 
   @Column('int', { name: 'group_num' })
   group_num: number;
+
+  @Column('varchar', { name: 'region_list', length: 30 })
+  regionList: string;
 
   @Column('int', { name: 'category_participants', default: 0 })
   categoryParticipations: number;
@@ -39,6 +46,13 @@ export class Plans {
 
   @Column('date', { name: 'end_date' })
   endDate: Date;
+
+  @Column('enum', {
+    name: 'status',
+    enum: PlanStatus,
+    default: PlanStatus.READY,
+  })
+  status: PlanStatus;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/entities/Plans.ts
+++ b/backend/src/entities/Plans.ts
@@ -14,9 +14,8 @@ import {
 import { Users } from './Users';
 import { CategoryResponses } from './CategoryResponses';
 import { SpotResponses } from './SpotResponses';
-import { Spots } from './Spots';
 import { Recommends } from './Recommends';
-import { PlanStatus } from 'src/dto/plan.detail.response.dto';
+import { PlanStatus } from './common/PlanStatus';
 
 @Entity({ schema: 'frienvel', name: 'plans' })
 export class Plans {
@@ -47,7 +46,8 @@ export class Plans {
   @Column('date', { name: 'end_date' })
   endDate: Date;
 
-  @Column('enum', {
+  @Column({
+    type: 'enum',
     name: 'status',
     enum: PlanStatus,
     default: PlanStatus.READY,

--- a/backend/src/entities/common/PlanStatus.ts
+++ b/backend/src/entities/common/PlanStatus.ts
@@ -1,0 +1,7 @@
+// TODO: 취향 조사 중, 설문 조사 중 등등 여러가지 상태가 있을 수 있음
+
+export enum PlanStatus {
+  READY = '계획중',
+  ING = '여행중',
+  END = '여행완료',
+}

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -8,7 +8,6 @@ import {
   Put,
   UseGuards,
   Param,
-  Query,
 } from '@nestjs/common';
 import { PlansService } from './plans.service';
 import {
@@ -23,7 +22,6 @@ import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
 import { ErrorResponseDto } from 'src/dto/error.response.dto';
 import { PlanSimpleResponseDto } from 'src/dto/plan.simple.response.dto';
 import { User } from 'src/decorators/user.decorator';
-import { UserResponseDto } from 'src/dto/user.response.dto';
 
 @ApiTags('PLAN')
 @Controller('api/plans')
@@ -45,7 +43,7 @@ export class PlansController {
     @User() user,
     @Body() body: PlanRequestDto,
   ): Promise<PlanDetailResponseDto> {
-    //TODO : 여행 계획 생성하기
+    // 여행 계획 생성하기
     const plan = await this.plansService.createPlan(
       user ? user.id : null,
       body,
@@ -57,12 +55,11 @@ export class PlansController {
     }
   }
 
-  @ApiOperation({ summary: '여행 계획 수정하기' })
+  @ApiOperation({ summary: '여행 계획 수정하기 // 우선 구현 skip함' })
   @Put()
   @UseGuards(LoggedInGuard)
   async updatePlan() {
     //TODO : 여행 계획 수정하기
-    // 일단 skip
   }
 
   @ApiOkResponse({
@@ -73,10 +70,10 @@ export class PlansController {
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 삭제하기' })
-  @Delete()
+  @Delete(':planId')
   @UseGuards(LoggedInGuard)
-  async deletePlan(@Query('planId') planId: number): Promise<void> {
-    //TODO : 여행 계획 삭제하기
+  async deletePlan(@Param('planId') planId: number): Promise<void> {
+    // 여행 계획 삭제하기
     await this.plansService.deletePlan(planId);
   }
 
@@ -89,12 +86,12 @@ export class PlansController {
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 id로 조회하기 (회원 기준)' })
-  @Get()
+  @Get('planId/:planId')
   async getPlanWithId(
-    @Query('planId') planId: number,
+    @Param('planId') planId: number,
   ): Promise<PlanDetailResponseDto> {
-    //TODO : 여행 계획 id로 조회하기
-    //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
+    // 여행 계획 id로 조회하기
+    // 현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
     const plan = await this.plansService.getPlanWithId(planId);
     if (plan) {
       return plan;
@@ -112,10 +109,12 @@ export class PlansController {
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 링크로 조회하기 (비회원 기준)' })
-  @Get()
-  async getPlanWithHashId(@Query('hashId') hashId: string) {
-    //TODO : 여행 계획 link주소로 조회하기
-    //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
+  @Get('hashId/:hashId')
+  async getPlanWithHashId(
+    @Param('hashId') hashId: string,
+  ): Promise<PlanDetailResponseDto> {
+    // 여행 계획 link주소로 조회하기
+    // 현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
     const plan = await this.plansService.getPlanWithHashId(hashId);
     if (plan) {
       return plan;
@@ -136,8 +135,8 @@ export class PlansController {
   @ApiOperation({ summary: '사용자 정보로 사용자가 속한 모든 여행 조회하기' })
   @Get('all')
   @UseGuards(LoggedInGuard)
-  getAllPlan(@User() user) {
-    //TODO : 내가 속한 모든 여행 조회하기
+  getAllPlan(@User() user): Promise<PlanSimpleResponseDto[]> {
+    // 내가 속한 모든 여행 조회하기
     // 세부 사항이 아니라, 간단하게 현황과 날짜, 참여하고 있는 사람들의 프사같은 정보
     const planList = this.plansService.getAllPlan(user.id);
     if (planList) {

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -35,23 +35,20 @@ export class PlansController {
     type: PlanDetailResponseDto,
   })
   @ApiNotFoundResponse({
-    description: '잘못된 요청입니다.',
+    description: '여행 계획 생성 실패',
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 생성하기' })
   @Post()
   @UseGuards(LoggedInGuard)
   async createPlan(
+    @User() user,
     @Body() body: PlanRequestDto,
   ): Promise<PlanDetailResponseDto> {
     //TODO : 여행 계획 생성하기
     const plan = await this.plansService.createPlan(
-      // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
-      body.user.id,
-      body.groupNum,
-      body.regionList,
-      body.startDate,
-      body.endDate,
+      user ? user.id : null,
+      body,
     );
     if (plan) {
       return plan;
@@ -68,6 +65,13 @@ export class PlansController {
     // 일단 skip
   }
 
+  @ApiOkResponse({
+    description: '여행 계획 삭제 성공',
+  })
+  @ApiNotFoundResponse({
+    description: '여행 계획이 존재하지 않습니다.',
+    type: ErrorResponseDto,
+  })
   @ApiOperation({ summary: '여행 계획 삭제하기' })
   @Delete()
   @UseGuards(LoggedInGuard)
@@ -77,14 +81,14 @@ export class PlansController {
   }
 
   @ApiOkResponse({
-    description: '여행 계획 조회 성공',
+    description: '여행 계획 id로 여행 계획 조회 성공',
     type: PlanDetailResponseDto,
   })
   @ApiNotFoundResponse({
-    description: '잘못된 요청입니다.',
+    description: '여행 계획이 존재하지 않습니다.',
     type: ErrorResponseDto,
   })
-  @ApiOperation({ summary: '여행 계획 id로 조회하기' })
+  @ApiOperation({ summary: '여행 계획 id로 조회하기 (회원 기준)' })
   @Get()
   async getPlanWithId(
     @Query('planId') planId: number,
@@ -100,14 +104,14 @@ export class PlansController {
   }
 
   @ApiOkResponse({
-    description: '여행 계획 조회 성공',
+    description: '여행 계획 링크로 여행 계획 조회 성공',
     type: PlanDetailResponseDto,
   })
   @ApiNotFoundResponse({
-    description: '잘못된 요청입니다.',
+    description: '여행 계획이 존재하지 않습니다.',
     type: ErrorResponseDto,
   })
-  @ApiOperation({ summary: '여행 계획 링크로 조회하기' })
+  @ApiOperation({ summary: '여행 계획 링크로 조회하기 (비회원 기준)' })
   @Get()
   async getPlanWithHashId(@Query('hashId') hashId: string) {
     //TODO : 여행 계획 link주소로 조회하기
@@ -132,10 +136,10 @@ export class PlansController {
   @ApiOperation({ summary: '사용자 정보로 사용자가 속한 모든 여행 조회하기' })
   @Get('all')
   @UseGuards(LoggedInGuard)
-  getAllPlan(@User() user: UserResponseDto) {
+  getAllPlan(@User() user) {
     //TODO : 내가 속한 모든 여행 조회하기
     // 세부 사항이 아니라, 간단하게 현황과 날짜, 참여하고 있는 사람들의 프사같은 정보
-    const planList = this.plansService.getAllPlan(user);
+    const planList = this.plansService.getAllPlan(user.id);
     if (planList) {
       return planList;
     } else {

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
   UseGuards,
   Param,
+  Query,
 } from '@nestjs/common';
 import { PlansService } from './plans.service';
 import {
@@ -42,7 +43,7 @@ export class PlansController {
     //TODO : 여행 계획 생성하기
     const plan = await this.plansService.createPlan(
       // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
-      body.userId,
+      body.user.id,
       body.groupNum,
       body.regionList,
       body.startDate,
@@ -80,11 +81,11 @@ export class PlansController {
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 id로 조회하기' })
-  @Get(':id')
-  async getPlanWithId(@Param('id') id: number) {
-    //TODO : 여행 계획 link주소로 조회하기
+  @Get()
+  async getPlanWithId(@Query('planId') planId: number) {
+    //TODO : 여행 계획 id로 조회하기
     //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
-    const plan = await this.plansService.getPlanWithId(id);
+    const plan = await this.plansService.getPlanWithId(planId);
     if (plan) {
       return plan;
     } else {
@@ -101,8 +102,8 @@ export class PlansController {
     type: ErrorResponseDto,
   })
   @ApiOperation({ summary: '여행 계획 링크로 조회하기' })
-  @Get(':hashId')
-  async getPlanWithHashId(@Param('hashId') hashId: string) {
+  @Get()
+  async getPlanWithHashId(@Query('hashId') hashId: string) {
     //TODO : 여행 계획 link주소로 조회하기
     //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
     const plan = await this.plansService.getPlanWithHashId(hashId);

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -17,7 +17,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { LoggedInGuard } from 'src/auth/logged-in-guard';
-import { PlanRequenstDto } from 'src/dto/plan.request.dto';
+import { PlanRequestDto } from 'src/dto/plan.request.dto';
 import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
 import { ErrorResponseDto } from 'src/dto/error.response.dto';
 import { PlanSimpleResponseDto } from 'src/dto/plan.simple.response.dto';
@@ -38,7 +38,7 @@ export class PlansController {
   @ApiOperation({ summary: '여행 계획 생성하기' })
   @Post()
   @UseGuards(LoggedInGuard)
-  async createPlan(@Body() body: PlanRequenstDto) {
+  async createPlan(@Body() body: PlanRequestDto) {
     //TODO : 여행 계획 생성하기
     const plan = await this.plansService.createPlan(
       // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -22,6 +22,8 @@ import { PlanRequestDto } from 'src/dto/plan.request.dto';
 import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
 import { ErrorResponseDto } from 'src/dto/error.response.dto';
 import { PlanSimpleResponseDto } from 'src/dto/plan.simple.response.dto';
+import { User } from 'src/decorators/user.decorator';
+import { UserResponseDto } from 'src/dto/user.response.dto';
 
 @ApiTags('PLAN')
 @Controller('api/plans')
@@ -39,7 +41,9 @@ export class PlansController {
   @ApiOperation({ summary: '여행 계획 생성하기' })
   @Post()
   @UseGuards(LoggedInGuard)
-  async createPlan(@Body() body: PlanRequestDto) {
+  async createPlan(
+    @Body() body: PlanRequestDto,
+  ): Promise<PlanDetailResponseDto> {
     //TODO : 여행 계획 생성하기
     const plan = await this.plansService.createPlan(
       // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
@@ -67,9 +71,9 @@ export class PlansController {
   @ApiOperation({ summary: '여행 계획 삭제하기' })
   @Delete()
   @UseGuards(LoggedInGuard)
-  async deletePlan() {
+  async deletePlan(@Query('planId') planId: number): Promise<void> {
     //TODO : 여행 계획 삭제하기
-    // 일단 skip
+    await this.plansService.deletePlan(planId);
   }
 
   @ApiOkResponse({
@@ -82,7 +86,9 @@ export class PlansController {
   })
   @ApiOperation({ summary: '여행 계획 id로 조회하기' })
   @Get()
-  async getPlanWithId(@Query('planId') planId: number) {
+  async getPlanWithId(
+    @Query('planId') planId: number,
+  ): Promise<PlanDetailResponseDto> {
     //TODO : 여행 계획 id로 조회하기
     //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
     const plan = await this.plansService.getPlanWithId(planId);
@@ -123,13 +129,13 @@ export class PlansController {
     description: '잘못된 요청입니다.',
     type: ErrorResponseDto,
   })
-  @ApiOperation({ summary: '사용자 id로 사용자가 속한 모든 여행 조회하기' })
-  @Get('all/:id')
+  @ApiOperation({ summary: '사용자 정보로 사용자가 속한 모든 여행 조회하기' })
+  @Get('all')
   @UseGuards(LoggedInGuard)
-  getAllPlan(@Param('id') id: number) {
+  getAllPlan(@User() user: UserResponseDto) {
     //TODO : 내가 속한 모든 여행 조회하기
     // 세부 사항이 아니라, 간단하게 현황과 날짜, 참여하고 있는 사람들의 프사같은 정보
-    const planList = this.plansService.getAllPlan(id);
+    const planList = this.plansService.getAllPlan(user);
     if (planList) {
       return planList;
     } else {

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -44,10 +44,7 @@ export class PlansController {
     @Body() body: PlanRequestDto,
   ): Promise<PlanDetailResponseDto> {
     // 여행 계획 생성하기
-    const plan = await this.plansService.createPlan(
-      user ? user.id : null,
-      body,
-    );
+    const plan = await this.plansService.createPlan(user.id, body);
     if (plan) {
       return plan;
     } else {

--- a/backend/src/plans/plans.controller.ts
+++ b/backend/src/plans/plans.controller.ts
@@ -1,46 +1,138 @@
-import { Controller, Delete, Get, Post, Put, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  Post,
+  Put,
+  UseGuards,
+  Param,
+} from '@nestjs/common';
 import { PlansService } from './plans.service';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { LoggedInGuard } from 'src/auth/logged-in-guard';
+import { PlanRequenstDto } from 'src/dto/plan.request.dto';
+import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
+import { ErrorResponseDto } from 'src/dto/error.response.dto';
+import { PlanSimpleResponseDto } from 'src/dto/plan.simple.response.dto';
 
 @ApiTags('PLAN')
 @Controller('api/plans')
 export class PlansController {
   constructor(private plansService: PlansService) {}
 
+  @ApiOkResponse({
+    description: '여행 계획 생성 성공',
+    type: PlanDetailResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
   @ApiOperation({ summary: '여행 계획 생성하기' })
   @Post()
   @UseGuards(LoggedInGuard)
-  createPlan() {
+  async createPlan(@Body() body: PlanRequenstDto) {
     //TODO : 여행 계획 생성하기
+    const plan = await this.plansService.createPlan(
+      // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
+      body.userId,
+      body.groupNum,
+      body.regionList,
+      body.startDate,
+      body.endDate,
+    );
+    if (plan) {
+      return plan;
+    } else {
+      throw new ForbiddenException();
+    }
   }
 
   @ApiOperation({ summary: '여행 계획 수정하기' })
   @Put()
   @UseGuards(LoggedInGuard)
-  updatePlan() {
+  async updatePlan() {
     //TODO : 여행 계획 수정하기
+    // 일단 skip
   }
 
   @ApiOperation({ summary: '여행 계획 삭제하기' })
   @Delete()
   @UseGuards(LoggedInGuard)
-  deletePlan() {
+  async deletePlan() {
     //TODO : 여행 계획 삭제하기
+    // 일단 skip
   }
 
+  @ApiOkResponse({
+    description: '여행 계획 조회 성공',
+    type: PlanDetailResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
   @ApiOperation({ summary: '여행 계획 id로 조회하기' })
-  @Get()
-  getPlan() {
+  @Get(':id')
+  async getPlanWithId(@Param('id') id: number) {
     //TODO : 여행 계획 link주소로 조회하기
     //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
+    const plan = await this.plansService.getPlanWithId(id);
+    if (plan) {
+      return plan;
+    } else {
+      throw new ForbiddenException();
+    }
   }
 
-  @ApiOperation({ summary: '내가 속한 모든 여행 조회하기' })
-  @Get('all')
+  @ApiOkResponse({
+    description: '여행 계획 조회 성공',
+    type: PlanDetailResponseDto,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
+  @ApiOperation({ summary: '여행 계획 링크로 조회하기' })
+  @Get(':hashId')
+  async getPlanWithHashId(@Param('hashId') hashId: string) {
+    //TODO : 여행 계획 link주소로 조회하기
+    //현재 상태, 여행 동행인원, 설문 참여인원, 생성자, 참여자 등등 자세히
+    const plan = await this.plansService.getPlanWithHashId(hashId);
+    if (plan) {
+      return plan;
+    } else {
+      throw new ForbiddenException();
+    }
+  }
+
+  @ApiOkResponse({
+    description: '내가 속한 모든 여행 조회 성공',
+    type: PlanSimpleResponseDto,
+    isArray: true,
+  })
+  @ApiNotFoundResponse({
+    description: '잘못된 요청입니다.',
+    type: ErrorResponseDto,
+  })
+  @ApiOperation({ summary: '사용자 id로 사용자가 속한 모든 여행 조회하기' })
+  @Get('all/:id')
   @UseGuards(LoggedInGuard)
-  getAllPlan() {
+  getAllPlan(@Param('id') id: number) {
     //TODO : 내가 속한 모든 여행 조회하기
-    //세부 사항이 아니라, 간단하게 현황과 날짜, 참여하고 있는 사람들의 프사같은 정보
+    // 세부 사항이 아니라, 간단하게 현황과 날짜, 참여하고 있는 사람들의 프사같은 정보
+    const planList = this.plansService.getAllPlan(id);
+    if (planList) {
+      return planList;
+    } else {
+      throw new ForbiddenException();
+    }
   }
 }

--- a/backend/src/plans/plans.module.ts
+++ b/backend/src/plans/plans.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 import { PlansController } from './plans.controller';
 import { PlansService } from './plans.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Plans } from 'src/entities/Plans';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Plans])],
   controllers: [PlansController],
-  providers: [PlansService]
+  providers: [PlansService],
 })
 export class PlansModule {}

--- a/backend/src/plans/plans.module.ts
+++ b/backend/src/plans/plans.module.ts
@@ -3,9 +3,10 @@ import { PlansController } from './plans.controller';
 import { PlansService } from './plans.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Plans } from 'src/entities/Plans';
+import { Users } from 'src/entities/Users';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Plans])],
+  imports: [TypeOrmModule.forFeature([Plans, Users])],
   controllers: [PlansController],
   providers: [PlansService],
 })

--- a/backend/src/plans/plans.service.ts
+++ b/backend/src/plans/plans.service.ts
@@ -26,12 +26,12 @@ export class PlansService {
   }
 
   async getPlanWithId(id: number) {
-    //TODO : 여행 계획 조회하기
+    //TODO : 여행 계획 id로 조회하기
     return true;
   }
 
   async getPlanWithHashId(hash: string) {
-    //TODO : 여행 계획 조회하기
+    //TODO : 여행 계획 hash id로 조회하기
     return true;
   }
 

--- a/backend/src/plans/plans.service.ts
+++ b/backend/src/plans/plans.service.ts
@@ -1,4 +1,42 @@
 import { Injectable } from '@nestjs/common';
+import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
 
 @Injectable()
-export class PlansService {}
+export class PlansService {
+  constructor() {}
+
+  async createPlan(
+    userId: number,
+    groupNum: number,
+    regionList: string,
+    startDate: Date,
+    endDate: Date,
+  ) {
+    //TODO : 여행 계획 생성하기
+    // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
+    return true;
+  }
+
+  async updatePlan() {
+    //TODO : 여행 계획 수정하기
+  }
+
+  async deletePlan() {
+    //TODO : 여행 계획 삭제하기
+  }
+
+  async getPlanWithId(id: number) {
+    //TODO : 여행 계획 조회하기
+    return true;
+  }
+
+  async getPlanWithHashId(hash: string) {
+    //TODO : 여행 계획 조회하기
+    return true;
+  }
+
+  async getAllPlan(id: number) {
+    //TODO : 여행 계획 전체 조회하기
+    return true;
+  }
+}

--- a/backend/src/plans/plans.service.ts
+++ b/backend/src/plans/plans.service.ts
@@ -1,9 +1,14 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
+import { Plans } from 'src/entities/Plans';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class PlansService {
-  constructor() {}
+  constructor(
+    @InjectRepository(Plans) private plansRepository: Repository<Plans>,
+  ) {}
 
   async createPlan(
     userId: number,

--- a/backend/src/plans/plans.service.ts
+++ b/backend/src/plans/plans.service.ts
@@ -1,13 +1,24 @@
+import { User } from './../decorators/user.decorator';
+import { CategoryResponses } from './../entities/CategoryResponses';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { PlanDetailResponseDto } from 'src/dto/plan.detail.response.dto';
+import {
+  PlanDetailResponseDto,
+  PlanStatus,
+} from 'src/dto/plan.detail.response.dto';
 import { Plans } from 'src/entities/Plans';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
+import { PlanSimpleResponseDto } from 'src/dto/plan.simple.response.dto';
+import { UserResponseDto } from 'src/dto/user.response.dto';
+import { Users } from 'src/entities/Users';
 
 @Injectable()
 export class PlansService {
   constructor(
-    @InjectRepository(Plans) private plansRepository: Repository<Plans>,
+    @InjectRepository(Plans)
+    private plansRepository: Repository<Plans>,
+    @InjectRepository(Users)
+    private usersRepository: Repository<Users>,
   ) {}
 
   async createPlan(
@@ -16,32 +27,112 @@ export class PlansService {
     regionList: string,
     startDate: Date,
     endDate: Date,
-  ) {
+  ): Promise<PlanDetailResponseDto> {
     //TODO : 여행 계획 생성하기
     // 여행지 선택에서 제주도를 선택하긴 하지만 실제 db에는 저장하지 않음
-    return true;
+
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+
+    const newPlan = new Plans();
+    newPlan.userId = userId;
+    newPlan.link = btoa(
+      userId.toString() + '_' + this.plansRepository.count().toString(), // binary to ASCII
+    );
+    newPlan.group_num = groupNum;
+    newPlan.regionList = regionList;
+    newPlan.categoryParticipations = 0;
+    newPlan.spotParticipations = 0;
+    newPlan.startDate = startDate;
+    newPlan.endDate = endDate;
+    newPlan.status = PlanStatus.READY;
+    newPlan.ParticipantsList = [user];
+
+    const savedPlan = await this.plansRepository.save(newPlan);
+    const planDetailResponse: PlanDetailResponseDto = {
+      planId: savedPlan.id,
+      userId: savedPlan.userId,
+      link: savedPlan.link,
+      groupNum: savedPlan.group_num,
+      regionList: savedPlan.regionList,
+      categoryParticipants: 0,
+      spotParticipants: 0,
+      startDate: savedPlan.startDate,
+      endDate: savedPlan.endDate,
+      status: savedPlan.status,
+    };
+
+    return Promise.resolve(planDetailResponse);
   }
 
   async updatePlan() {
     //TODO : 여행 계획 수정하기
   }
 
-  async deletePlan() {
+  async deletePlan(id: number): Promise<void> {
     //TODO : 여행 계획 삭제하기
+    await this.plansRepository.delete(id);
   }
 
-  async getPlanWithId(id: number) {
+  async getPlanWithId(id: number): Promise<PlanDetailResponseDto> {
     //TODO : 여행 계획 id로 조회하기
-    return true;
+    const plan = await this.plansRepository.findOne({ where: { id } });
+    const planDetailResponse: PlanDetailResponseDto = {
+      planId: plan.id,
+      userId: plan.userId,
+      link: plan.link,
+      groupNum: plan.group_num,
+      regionList: plan.regionList,
+      categoryParticipants: plan.categoryParticipations,
+      spotParticipants: plan.spotParticipations,
+      startDate: plan.startDate,
+      endDate: plan.endDate,
+      status: plan.status,
+    };
+    return Promise.resolve(planDetailResponse);
   }
 
-  async getPlanWithHashId(hash: string) {
+  async getPlanWithHashId(hash: string): Promise<PlanDetailResponseDto> {
     //TODO : 여행 계획 hash id로 조회하기
-    return true;
+    const plan = await this.plansRepository.findOne({
+      where: { link: atob(hash) },
+    });
+    const planDetailResponse: PlanDetailResponseDto = {
+      planId: plan.id,
+      userId: plan.userId,
+      link: plan.link,
+      groupNum: plan.group_num,
+      regionList: plan.regionList,
+      categoryParticipants: plan.categoryParticipations,
+      spotParticipants: plan.spotParticipations,
+      startDate: plan.startDate,
+      endDate: plan.endDate,
+      status: plan.status,
+    };
+    return Promise.resolve(planDetailResponse);
   }
 
-  async getAllPlan(id: number) {
-    //TODO : 여행 계획 전체 조회하기
-    return true;
+  async getAllPlan(user: UserResponseDto): Promise<PlanSimpleResponseDto[]> {
+    //TODO : participant_list에서 userid가 속한 모든 여행 계획 전체 조회하기
+    const plans = await this.plansRepository
+      .createQueryBuilder('plans')
+      .leftJoinAndSelect('plans.ParticipantList', 'participantList')
+      .where('participantList.userId = :userId', { userId: user.id })
+      .getMany();
+
+    const planSimpleResponse: PlanSimpleResponseDto[] = [];
+    plans.forEach((plan) => {
+      planSimpleResponse.push({
+        planId: plan.id,
+        userId: plan.userId,
+        groupNum: plan.group_num,
+        startDate: plan.startDate,
+        endDate: plan.endDate,
+        status: plan.status,
+        profileImg: plan.ParticipantsList.map((participant) => {
+          return participant.profileImage;
+        }),
+      });
+    });
+    return Promise.resolve(planSimpleResponse);
   }
 }

--- a/backend/src/plans/plans.service.ts
+++ b/backend/src/plans/plans.service.ts
@@ -81,6 +81,12 @@ export class PlansService {
     return Promise.resolve(planDetailResponse);
   }
 
+  async getParticipantsStatus(planId: number) {
+    // 여행 id를 받아서, 동행인원의 이름과, 각각이 취향설문과 여행지 설문을 참여했는지 반환하기
+    //{"name":["홍길동", "철수", "짱구"], "categoryResponseStatus" : [true, false, true, true, false], "spotResponseStatus" : [true, false, true, true, false]
+    //이거 구현해서, getPlanwithId랑HashId에 정보 추가해서 보내주기
+  }
+
   async getPlanWithHashId(hashId: string): Promise<PlanDetailResponseDto> {
     // 여행 계획 hash id로 조회하기
     const plan = await this.plansRepository.findOne({

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -22,6 +22,7 @@ import {
 } from '@nestjs/swagger';
 import { UserResponseDto } from 'src/dto/user.response.dto';
 import { ErrorResponseDto } from 'src/dto/error.response.dto';
+import { Users } from 'src/entities/Users';
 
 @ApiTags('USER')
 @Controller('api/users')
@@ -38,7 +39,7 @@ export class UsersController {
   })
   @ApiOperation({ summary: '내 정보 가져오기' })
   @Get()
-  getUsers(@User() user: UserResponseDto) {
+  getUsers(@User() user) {
     if (!user) throw new NotFoundException();
     return user;
   }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -38,7 +38,7 @@ export class UsersController {
   })
   @ApiOperation({ summary: '내 정보 가져오기' })
   @Get()
-  getUsers(@User() user) {
+  getUsers(@User() user: UserResponseDto) {
     if (!user) throw new NotFoundException();
     return user;
   }


### PR DESCRIPTION
Plan module 구현

POST /api/plans : PlanRequestDto → PlanDetailResponseDto
GET /api/plans/planId/123 : 123 → PlanDetailResponseDtp (plan id param으로 get)
GET /api/plans/hashId/ABC : ABC → PlanDetailResponseDto (hash id param으로 get)
GET /api/plans/all : ( ) → PlanSimpleResponseDto
DELETE /api/plans/123: 123 → ..

PUT /api/plans (일단 skip 나중에 구현 예정)

- PlanRequestDto
소유자 정보 (UserResponseDto), 동행 인원 (Number), 지역 (east, west, south, north), 여행 시작일(Date), 여행 종료일(Date)

- PlanSimpleResponseDto
여행계획 아이디 (int), 소유자 아이디 (int), 동행 인원 (Number)
여행 시작일 (Date), 여행 종료일(Date), 상태 (enum: ready, ing, end), 카카오톡 프로필 (string [])

- PlanDetailResponseDto
여행계획 아이디 (int), 소유자 아이디 (int), 설문 주소 (string), 동행 인원 (Number), 지역 (east, west, south, north)
취향설문참여인원 (int), 여행지설문참여인원 (int), 여행 시작일(Date), 여행 종료일(Date), 상태 (enum: ready, ing, end)

// TODO: enum 상태 종류 변경
// TODO: 추후에 logout 수정 필요